### PR TITLE
Clean up things related to compiled code

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,12 +18,10 @@ Depends:
     methods,
     stats
 Imports:
-    Rcpp (>= 0.12.8),
     Matrix,
     glmnet
 Suggests: R.rsp
 VignetteBuilder: R.rsp
-LinkingTo: Rcpp
 Collate:
     'transform_class.R'
     'performance_class.R'

--- a/src/register.c
+++ b/src/register.c
@@ -1,0 +1,7 @@
+#include <Rinternals.h>
+#include <R_ext/Rdynload.h>
+
+void R_init_binnr(DllInfo* dll) {
+  R_registerRoutines(dll, NULL, NULL, NULL, NULL);
+  R_useDynamicSymbols(dll, TRUE);
+}


### PR DESCRIPTION
This PR contains two commits.

The first commit removes Rcpp from the package....Rcpp was listed in `Imports` and `LinkingTo`, but was not being used anywhere in the package.

The second commit adds a new file, `register.c`, the purpose is simply to avoid a note related to compiled code during `R CMD Check`:
```
❯ checking compiled code ... NOTE
  File ‘binnr/libs/binnr.so’:
    Found no calls to: ‘R_registerRoutines’, ‘R_useDynamicSymbols’
  
  It is good practice to register native routines and to disable symbol
  search.
  
  See ‘Writing portable packages’ in the ‘Writing R Extensions’ manual.
```
The fix is similar to that used by [jsonlite](https://github.com/jeroen/jsonlite/blob/master/src/register.c). The `note` disappears after adding the `register.c` file.

Let me know if you'd like me to tweak anything, I'm happy to make edits to this PR if need be.